### PR TITLE
feat(secret): hide private key/seed behind an encryptor

### DIFF
--- a/src/basic/exceptions.ts
+++ b/src/basic/exceptions.ts
@@ -1,3 +1,5 @@
 class NotImplementedError extends Error {}
 
-export { NotImplementedError };
+class IncorrectPassword extends Error {}
+
+export { NotImplementedError, IncorrectPassword };

--- a/src/secret/encryptors/aes256.ts
+++ b/src/secret/encryptors/aes256.ts
@@ -1,0 +1,51 @@
+import * as crypto from 'crypto';
+
+import { IncorrectPassword } from '../../basic/exceptions';
+import { sha256 } from '../hash';
+
+const ALGORITHM = 'aes-256-cbc';
+const PBKDF2_NUM_OF_ITERATIONS = 5000;
+const PBKDF2_DIGEST_METHOD = 'sha256';
+const PBKDF2_KEY_LENGTH = 32;
+const PBKDF2_SALT_LENGTH = 32;
+const AES256_IV_LENGTH = 16;
+const ENCRYPTED_DATA_OFFSET = PBKDF2_SALT_LENGTH + AES256_IV_LENGTH;
+
+function keyFromPasswordAndSalt(password: string, salt: Buffer): Buffer {
+  return crypto.pbkdf2Sync(
+    sha256(Buffer.from(password, 'utf8')),
+    salt,
+    PBKDF2_NUM_OF_ITERATIONS,
+    PBKDF2_KEY_LENGTH,
+    PBKDF2_DIGEST_METHOD,
+  );
+}
+
+function encrypt(password: string, data: Buffer): Buffer {
+  const salt: Buffer = crypto.randomBytes(PBKDF2_SALT_LENGTH);
+  const key: Buffer = keyFromPasswordAndSalt(password, salt);
+  const iv: Buffer = crypto.randomBytes(AES256_IV_LENGTH);
+  const cipher: crypto.Cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+
+  const chunked: Buffer = cipher.update(data);
+  const final: Buffer = cipher.final();
+
+  return Buffer.concat([salt, iv, chunked, final]);
+}
+
+function decrypt(password: string, data: Buffer): Buffer {
+  const salt: Buffer = data.slice(0, PBKDF2_SALT_LENGTH);
+  const key: Buffer = keyFromPasswordAndSalt(password, salt);
+  const iv: Buffer = data.slice(PBKDF2_SALT_LENGTH, ENCRYPTED_DATA_OFFSET);
+  const decipher: crypto.Decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+
+  try {
+    const chunked: Buffer = decipher.update(data.slice(ENCRYPTED_DATA_OFFSET));
+    const final: Buffer = decipher.final();
+    return Buffer.concat([chunked, final]);
+  } catch {
+    throw new IncorrectPassword();
+  }
+}
+
+export { encrypt, decrypt };

--- a/src/secret/hash.ts
+++ b/src/secret/hash.ts
@@ -4,4 +4,8 @@ function hmacSHA512(key: Buffer, data: Buffer): Buffer {
   return crypto.createHmac('sha512', key).update(data).digest();
 }
 
-export { hmacSHA512 };
+function sha256(data: Buffer): Buffer {
+  return crypto.createHash('sha256').update(data).digest();
+}
+
+export { hmacSHA512, sha256 };


### PR DESCRIPTION
## What does this implement/fix? Explain your changes.
password based encryptor to encrypt & decrypt private keys and seeds.

## Does this close any currently open issues?

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

_Put an `x` in the boxes that apply_

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Where has this been tested?

## Any other comments?